### PR TITLE
Fixed a typo which prevented autoRecording from stopping

### DIFF
--- a/MFCRecorder.py
+++ b/MFCRecorder.py
@@ -171,7 +171,7 @@ def startRecording(model):
         if not os.path.exists(directory):
             os.makedirs(directory)
         with open(filePath, 'wb') as f:
-            minViewers = filter['autoStopViewers'] if model['condition'] == 'viewers' else filter['stopViewers']
+            minViewers = filter['autoStopViewers'] if model['condition'] == 'VIEWERS_' else filter['stopViewers']
             while modelDict[model['uid']]['rc'] >= minViewers:
                 try:
                     data = fd.read(1024)


### PR DESCRIPTION
I noticed that models that were autoRecorded where not stopping if their roomcount fell below the value i had set for autoStopViewers. 

i then noticed that the check for the model condition was incorrect due to a typo and autoRecording thus falling back to stopViewers which i hadn't set an thus models were recorded till they went offline or into a show of some sorts.