### PR TITLE
Added the option to set a minimum amount of viewers for tag recording

### DIFF
--- a/classes/config.py
+++ b/classes/config.py
@@ -47,6 +47,7 @@ class Filter():
         self.stop_viewers = parser.getint('settings', 'stop_viewers')
         self.min_tags = max(1, parser.getint('auto_recording', 'min_tags'))
         self._wanted_tags_str = parser.get('auto_recording', 'tags')
+        self.tag_min_viewers = parser.getint('auto_recording', 'min_viewers')
         self._update_tags()
         #account for when stop is greater than min
         self.min_viewers = max(self.stop_viewers, parser.getint('settings', 'min_viewers'))
@@ -128,7 +129,7 @@ class Config():
             return False
         if f.wanted_tags:
             matches = f.wanted_tags.intersection(model.tags if model.tags is not None else [])
-            if len(matches) >= f.min_tags:
+            if len(matches) >= f.min_tags and model.session['rc'] >= f.tag_min_viewers:
                 model.session['condition'] = '({})_'.format(','.join(matches))
                 return True
         if f.newer_than_hours and model.session['creation'] > int(time.time()) - f.newer_than_hours * 60 * 60:

--- a/config.sample.conf
+++ b/config.sample.conf
@@ -92,6 +92,7 @@ newer_than_hours = 0
 #   set the minimum number of tags required to start recording a model.
 tags = 0
 min_tags = 0
+min_viewers = 0
 
 [web]
 port = 8778


### PR DESCRIPTION
wanted an option to limit the amount of low quality tag recordings. setting an minimum amount of viewers helps with that.