### PR TITLE
Fixed blacklist checking for some edgecases

### DIFF
--- a/classes/config.py
+++ b/classes/config.py
@@ -265,6 +265,6 @@ class Wanted():
     def _is_list_mode_value(self, uid, value):
         '''determines if list_mode equals the specified one, but only if the item is enabled'''
         entry = self.dict.get(uid)
-        if not (entry and entry['enabled'] and self._settings.priority <= entry['priority']):
+        if not entry or entry['enabled'] != True or entry['priority'] <= self._settings.priority:
             return False
         return entry['list_mode'] == value


### PR DESCRIPTION
Fixed blacklist checking for some edgecases where models matched wanted tags and were blacklisted at the same time resulting in recordings not being stopped